### PR TITLE
handle ca bundle updates

### DIFF
--- a/Network/ZitiTunnelDelegate.swift
+++ b/Network/ZitiTunnelDelegate.swift
@@ -431,8 +431,15 @@ class ZitiTunnelDelegate: NSObject, CZiti.ZitiTunnelProvider {
     }
     
     private func handleApiEvent(_ ziti:Ziti, _ tzid:ZitiIdentity, _ event:ZitiTunnelApiEvent) {
-        zLog.info("Saving zid file, newControllerAddress=\(event.newControllerAddress).")
-        tzid.czid?.ztAPI = event.newControllerAddress
+        zLog.info("Saving zid file\n" +
+                  "   newControllerAddress=\(event.newControllerAddress)\n" +
+                  "   newCaBundle=\(event.newCaBundle).")
+        if !event.newControllerAddress.isEmpty {
+            tzid.czid?.ztAPI = event.newControllerAddress
+        }
+        if !event.newCaBundle.isEmpty {
+            tzid.czid?.ca = event.newCaBundle
+        }
         _ = zidStore.update(tzid, [.CZitiIdentity, .ControllerVersion])
     }
     

--- a/Network/ZitiTunnelDelegate.swift
+++ b/Network/ZitiTunnelDelegate.swift
@@ -434,12 +434,7 @@ class ZitiTunnelDelegate: NSObject, CZiti.ZitiTunnelProvider {
         zLog.info("Saving zid file\n" +
                   "   newControllerAddress=\(event.newControllerAddress)\n" +
                   "   newCaBundle=\(event.newCaBundle).")
-        if !event.newControllerAddress.isEmpty {
-            tzid.czid?.ztAPI = event.newControllerAddress
-        }
-        if !event.newCaBundle.isEmpty {
-            tzid.czid?.ca = event.newCaBundle
-        }
+        // tunnel provider has already updated tzid with event data before calling us, so just save the zid
         _ = zidStore.update(tzid, [.CZitiIdentity, .ControllerVersion])
     }
     

--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
-        "revision" : "27306b5b515ec7c570e2a824ee3e6e7ce0109897",
-        "version" : "0.30.17"
+        "revision" : "64e3dc0ab0b7a3862bf1891e0f0115a1e2e82e52",
+        "version" : "0.30.19"
       }
     }
   ],


### PR DESCRIPTION
depends on https://github.com/openziti/ziti-sdk-swift/tree/handle.ca.updates, which has not yet been released.