### PR TITLE
update ziti-sdk-swift@2.0.0-alpha5

### DIFF
--- a/MobilePacketTunnelProvider/Info.plist
+++ b/MobilePacketTunnelProvider/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.43</string>
+	<string>2.44</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/MobileShare/Info.plist
+++ b/MobileShare/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.43</string>
+	<string>2.44</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/PacketTunnelProvider/Info.plist
+++ b/PacketTunnelProvider/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.43</string>
+	<string>2.44</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ZitiMobilePacketTunnel/Info.plist
+++ b/ZitiMobilePacketTunnel/Info.plist
@@ -56,7 +56,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.43</string>
+	<string>2.44</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
-        "revision" : "05d2d6157e57a60330672a038dc91d1588d074cc",
-        "version" : "2.0.0-alpha4"
+        "revision" : "3a537c4ba6b4df13b2581710deb2920c25826beb",
+        "version" : "2.0.0-alpha5"
       }
     }
   ],

--- a/ZitiPacketTunnel/Info.plist
+++ b/ZitiPacketTunnel/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.43</string>
+	<string>2.44</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
Brings in ziti-tunnel-sdk-c v2.0.0-alpha25