### PR TITLE
update ziti-sdk-swift@0.40.4

### DIFF
--- a/MobilePacketTunnelProvider/Info.plist
+++ b/MobilePacketTunnelProvider/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.46</string>
+	<string>2.47</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/MobileShare/Info.plist
+++ b/MobileShare/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.46</string>
+	<string>2.47</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/PacketTunnelProvider/Info.plist
+++ b/PacketTunnelProvider/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.46</string>
+	<string>2.47</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ZitiMobilePacketTunnel/Info.plist
+++ b/ZitiMobilePacketTunnel/Info.plist
@@ -56,7 +56,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.46</string>
+	<string>2.47</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
-        "revision" : "6aa5c821d72200ca22b6234ed7b4fc2148b9c630",
-        "version" : "0.40.3"
+        "revision" : "b1711d08d7640c14f616997f843e27105ad051c2",
+        "version" : "0.40.4"
       }
     }
   ],

--- a/ZitiPacketTunnel/Info.plist
+++ b/ZitiPacketTunnel/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.46</string>
+	<string>2.47</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
includes ziti-sdk-c@1.1.5 which fixes a crash on wake when zde/zme is managing disabled identities.