### PR TITLE
update ziti-sdk-swift@0.41.7

### DIFF
--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
         "branch" : "alpha",
-        "revision" : "7506130be32b297a49e908e9e2eca3a0cac83db1"
+        "revision" : "f86550c5f2ff886f46662d3c4f24e0df88406d80"
       }
     }
   ],

--- a/ZitiPacketTunnel/ViewController.swift
+++ b/ZitiPacketTunnel/ViewController.swift
@@ -917,6 +917,7 @@ class ViewController: NSViewController, NSTextFieldDelegate {
                         zid.czid = CZiti.ZitiIdentity(id: zidResp.id, ztAPIs: [zidResp.ztAPI])
                     }
                     zid.czid?.ca = zidResp.ca
+                    zid.czid?.certCNs = zidResp.certCNs
                     if zidResp.name != nil {
                         zid.czid?.name = zidResp.name
                     }


### PR DESCRIPTION
also enable use of all certificates in enrollment responses