### PR TITLE
Handle identity certificate extension

### DIFF
--- a/MobilePacketTunnelProvider/Info.plist
+++ b/MobilePacketTunnelProvider/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.48</string>
+	<string>2.49</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/MobileShare/Info.plist
+++ b/MobileShare/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.48</string>
+	<string>2.49</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/Network/ZitiTunnelDelegate.swift
+++ b/Network/ZitiTunnelDelegate.swift
@@ -434,6 +434,7 @@ class ZitiTunnelDelegate: NSObject, CZiti.ZitiTunnelProvider {
         zLog.info("Saving zid file\n" +
                   "   controllerAddress=\(event.controllerUrl)\n" +
                   "   controllers=\(event.controllers)\n" +
+                  "   certPEM=\(event.certPEM)\n" +
                   "   caBundle=\(event.caBundle).")
         // tunnel provider has already updated tzid with event data before calling us, so just save the zid
         _ = zidStore.update(tzid, [.CZitiIdentity, .ControllerVersion])

--- a/PacketTunnelProvider/Info.plist
+++ b/PacketTunnelProvider/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.48</string>
+	<string>2.49</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ZitiMobilePacketTunnel/IdentityViewController.swift
+++ b/ZitiMobilePacketTunnel/IdentityViewController.swift
@@ -444,6 +444,7 @@ class IdentityViewController: UITableViewController, MFMailComposeViewController
                         zid.czid = CZiti.ZitiIdentity(id: zidResp.id, ztAPIs: [zidResp.ztAPI])
                     }
                     zid.czid?.ca = zidResp.ca
+                    zid.czid?.certs = zidResp.certs
                     if zidResp.name != nil {
                         zid.czid?.name = zidResp.name
                     }

--- a/ZitiMobilePacketTunnel/Info.plist
+++ b/ZitiMobilePacketTunnel/Info.plist
@@ -56,7 +56,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.48</string>
+	<string>2.49</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
         "branch" : "alpha",
-        "revision" : "b20cee4bda51482a2cf048e459b1a66256af9f8a"
+        "revision" : "fb21b08c2e64dae5cdec518b6642171fd51fc720"
       }
     }
   ],

--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
         "branch" : "alpha",
-        "revision" : "f86550c5f2ff886f46662d3c4f24e0df88406d80"
+        "revision" : "b20cee4bda51482a2cf048e459b1a66256af9f8a"
       }
     }
   ],

--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
         "branch" : "alpha",
-        "revision" : "fb21b08c2e64dae5cdec518b6642171fd51fc720"
+        "revision" : "bc75feedcc8e645d14aea4ced336228e939f4cfc"
       }
     }
   ],

--- a/ZitiPacketTunnel/Info.plist
+++ b/ZitiPacketTunnel/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.48</string>
+	<string>2.49</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSApplicationCategoryType</key>

--- a/ZitiPacketTunnel/ViewController.swift
+++ b/ZitiPacketTunnel/ViewController.swift
@@ -917,7 +917,7 @@ class ViewController: NSViewController, NSTextFieldDelegate {
                         zid.czid = CZiti.ZitiIdentity(id: zidResp.id, ztAPIs: [zidResp.ztAPI])
                     }
                     zid.czid?.ca = zidResp.ca
-                    zid.czid?.certCNs = zidResp.certCNs
+                    zid.czid?.certs = zidResp.certs
                     if zidResp.name != nil {
                         zid.czid?.name = zidResp.name
                     }


### PR DESCRIPTION
These are mostly cosmetic changes. The work for cert renewal is really being done in ziti-sdk-swift.