### PR TITLE
update ziti-sdk-swift@0.41.11

### DIFF
--- a/MobilePacketTunnelProvider/Info.plist
+++ b/MobilePacketTunnelProvider/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.49</string>
+	<string>2.50</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/MobileShare/Info.plist
+++ b/MobileShare/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.49</string>
+	<string>2.50</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/PacketTunnelProvider/Info.plist
+++ b/PacketTunnelProvider/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.49</string>
+	<string>2.50</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ZitiMobilePacketTunnel/Info.plist
+++ b/ZitiMobilePacketTunnel/Info.plist
@@ -56,7 +56,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.49</string>
+	<string>2.50</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
         "branch" : "alpha",
-        "revision" : "bc75feedcc8e645d14aea4ced336228e939f4cfc"
+        "revision" : "926ade8fa074c8534bcff2810e47569c9d6d71fa"
       }
     }
   ],

--- a/ZitiPacketTunnel/Info.plist
+++ b/ZitiPacketTunnel/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.49</string>
+	<string>2.50</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
brings ziti-sdk-c@1.6.5:
- ER (re)connection improvements
- improper/incomplete cert chain detection