### PR TITLE
update ziti-sdk-swift@0.41.46

### DIFF
--- a/MobilePacketTunnelProvider/Info.plist
+++ b/MobilePacketTunnelProvider/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.54</string>
+	<string>2.55</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/MobileShare/Info.plist
+++ b/MobileShare/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.54</string>
+	<string>2.55</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>NSExtension</key>

--- a/PacketTunnelProvider/Info.plist
+++ b/PacketTunnelProvider/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.54</string>
+	<string>2.55</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSMinimumSystemVersion</key>

--- a/ZitiMobilePacketTunnel/Info.plist
+++ b/ZitiMobilePacketTunnel/Info.plist
@@ -56,7 +56,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.54</string>
+	<string>2.55</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ZitiPacketTunnel.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/openziti/ziti-sdk-swift-dist.git",
       "state" : {
         "branch" : "main",
-        "revision" : "e3e8c049104a6c4c554aa530e1b37cc287304023"
+        "revision" : "89853fac9bbf9fad83d8274edce1dd520f71a9e9"
       }
     }
   ],

--- a/ZitiPacketTunnel/Info.plist
+++ b/ZitiPacketTunnel/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.54</string>
+	<string>2.55</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
includes ziti-tunnel-sdk-c@v1.11.2 / ziti-sdk-c@1.11.7:
  - openssl: fixes picking the wrong cert from the chain
  - improve session certificates lifecycle
