### PR TITLE
Only remove DNS entries for services with dial permission

### DIFF
--- a/Network/ZitiTunnelDelegate.swift
+++ b/Network/ZitiTunnelDelegate.swift
@@ -369,7 +369,9 @@ class ZitiTunnelDelegate: NSObject, CZiti.ZitiTunnelProvider {
         var reassert = false
         
         if remove {
-            self.dnsEntries.remove(serviceId)
+            if canDial(eSvc) {
+                self.dnsEntries.remove(serviceId)
+            }
             tzid.services = tzid.services.filter { $0.id != serviceId }
             reassert = true // could be smarter about this, but won't hurt (and removing service is less common that adding)
         }


### PR DESCRIPTION
The issue is likely only an issue in local testing environments where one identity is binding a service that a different identity is dialing. If the identity binding the service is disabled, the DNS intercept for the dialing identity is removed.  Added a "canDial" check before removing DNS entry when disabling a device...